### PR TITLE
Bugfix missing depdency from Coveralls package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
 	"require-dev": {
 		"phpunit/phpunit": "^6.0||^7.0",
 		"friendsofphp/php-cs-fixer": "^2.15",
-		"php-coveralls/php-coveralls": "^2.1"
+		"php-coveralls/php-coveralls": "^2.1",
+		"symfony/yaml": "^5.0"
 	},
 	"scripts": {
 		"lint": "php-cs-fixer fix",

--- a/src/LuhnAlgorithm.php
+++ b/src/LuhnAlgorithm.php
@@ -79,13 +79,14 @@ class LuhnAlgorithm implements LuhnAlgorithmInterface
      */
     public function calcChecksum(NumberInterface $number): int
     {
-        $nDigits = strlen($number->getNumber());
+        $num = $number->getNumber();
+        $nDigits = strlen($num);
         // Need to account for check digit
         $parity = ($nDigits + 1) % 2;
         $checksum = 0;
 
         for ($i = 0; $i < $nDigits; $i++) {
-            $digit = (int) $number->getNumber()[$i];
+            $digit = (int) $num[$i];
 
             // Every other digit, starting from the rightmost,
             // shall be doubled.

--- a/tests/LuhnAlgorithmTest.php
+++ b/tests/LuhnAlgorithmTest.php
@@ -95,6 +95,7 @@ class LuhnAlgorithmTest extends TestCase
     {
         return [
             "Valid checksum" => [new Number(3199723370002), 50],
+            "Checksum mod 10 is 0" => [new Number(31997), 30],
         ];
     }
 
@@ -112,6 +113,7 @@ class LuhnAlgorithmTest extends TestCase
             "Valid number" => [new Number(12345), 5],
             "Swedish company organization ID" => [new Number(559114884), 5],
             "Swedish organization number" => [new Number(640319261), 7],
+            "Checksum mod 10 is 0" => [new Number(31997), 0],
         ];
     }
 }


### PR DESCRIPTION
Coveralls is not running. They seem to have broken their package by adding a dependency on `symfony/yaml`, without actually adding it to there Composer.